### PR TITLE
Fix number input

### DIFF
--- a/Perplex.Umbraco.Forms/FieldTypes/PerplexTextField.cs
+++ b/Perplex.Umbraco.Forms/FieldTypes/PerplexTextField.cs
@@ -22,7 +22,7 @@ namespace PerplexUmbraco.Forms.FieldTypes
         public string MaximumLength { get; set; }
 
         [Umbraco.Forms.Core.Attributes.Setting("Type",
-        view = "dropdownlist", prevalues = "email,tel,text,numeric")]
+        view = "dropdownlist", prevalues = "email,tel,text,number")]
         public string FieldType { get; set; }
 
         [Umbraco.Forms.Core.Attributes.Setting("Additional attributes",


### PR DESCRIPTION
Hey guys,

I just found that the perplex text field was using "numeric" for a number type input, but the correct value is "number".

"numeric" is an inputmode as you can see here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

Cheers,
Cristhian.